### PR TITLE
Mudanças com integração do crud de user

### DIFF
--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /app/
 COPY . .
 RUN pip install -r requirements.txt
 
-CMD ["uvicorn", "api.main:api", "--reload", "--port", "8081", "--host", "0.0.0.0"]
+CMD ["uvicorn", "api.main:api", "--reload", "--port", "8080", "--host", "0.0.0.0"]

--- a/api/user/controller.py
+++ b/api/user/controller.py
@@ -19,13 +19,26 @@ def create(firebase_uid,request: UserRequest):
     user = UserRepository.create(firebase_uid, User(**request.dict()))
     return user
 
-@users.get("/{cpf}",
+@users.get("/user/cpf/{cpf}",
     status_code = status.HTTP_200_OK,
     response_model=UserResponse
 )
-def find_one(cpf):
+def find_one_by_cpf(cpf):
     '''Procura um usuário pelo cpf'''
     user = UserRepository.find_by_key(cpf)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Usuário não existe não encontrado"
+        )
+    return UserResponse.from_orm(user)
+
+@users.get("/user/uid/{firebase_uid}",
+    status_code = status.HTTP_200_OK,
+    response_model=UserResponse
+)
+def find_one_by_uid(firebase_uid):
+    '''Procura um usuário pelo firebase_uid'''
+    user = UserRepository.find_by_uid(firebase_uid)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Usuário não existe não encontrado"

--- a/api/user/controller.py
+++ b/api/user/controller.py
@@ -1,3 +1,4 @@
+from typing import List
 from fastapi import APIRouter, HTTPException, status
 
 from api.user.schema import UserRequest, UserResponse
@@ -47,7 +48,7 @@ def find_one_by_uid(firebase_uid):
 
 @users.get("/",
     status_code=status.HTTP_200_OK,
-    response_model=list[UserResponse]
+    response_model=List[UserResponse]
 )
 def find_all():
     users = UserRepository.find_all()
@@ -57,15 +58,16 @@ def find_all():
     status_code = status.HTTP_200_OK,
     response_model=UserResponse
 )
-def update(cpf, request: UserRequest):
+def update(cpf: str, request: UserRequest):
     '''atualiza os dados do usuario'''
     user = UserRepository.find_by_key(cpf)
     if user.status == 'inactive':
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Usuario inativo"
         )
-    user = UserRepository.update(User(**request.dict()))
-    return UserResponse.from_orm(user)
+    else:
+        updated_user = UserRepository.update(user.firebase_uid, User(**request.dict()))
+    return UserResponse.from_orm(updated_user)
 
 @users.put("/alterstatus/{cpf}",
     status_code = status.HTTP_200_OK,
@@ -78,5 +80,5 @@ def alter(cpf):
         user.status = 'active'
     else:
         user.status = 'inactive'
-    user = UserRepository.update(user)
+    user = UserRepository.update_status(user)
     return UserResponse.from_orm(user)

--- a/api/user/schema.py
+++ b/api/user/schema.py
@@ -21,7 +21,6 @@ class UserRequest(UserBase):
     '''...'''
 
 class UserResponse(UserBase):
-    firebase_uid: str
     '''Classe para definir o Usuário devolvido pela API'''
     firebase_uid: str
     class Config:

--- a/api/user/schema.py
+++ b/api/user/schema.py
@@ -21,6 +21,7 @@ class UserRequest(UserBase):
     '''...'''
 
 class UserResponse(UserBase):
+    firebase_uid: str
     '''Classe para definir o Usuário devolvido pela API'''
     class Config:
         orm_mode = True

--- a/api/user/schema.py
+++ b/api/user/schema.py
@@ -23,5 +23,6 @@ class UserRequest(UserBase):
 class UserResponse(UserBase):
     firebase_uid: str
     '''Classe para definir o Usuário devolvido pela API'''
+    firebase_uid: str
     class Config:
         orm_mode = True

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       context: .
       dockerfile: api.Dockerfile
     ports:
-      - '8080:8080'
+      - '8081:8081'
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       context: .
       dockerfile: api.Dockerfile
     ports:
-      - '8081:8081'
+      - '8080:8080'
     depends_on:
       db:
         condition: service_healthy

--- a/lib/dao/models/user.py
+++ b/lib/dao/models/user.py
@@ -11,7 +11,7 @@ class User(Base):
     email: str = Column(String(100), nullable=False)
     cpf: str = Column(String(100), primary_key=True, nullable=False, index=True)
     is_admin: bool = Column(Boolean, default=False)
-    telefone: int = Column(String(100), nullable=False)
+    telefone: str = Column(String(100), nullable=False)
     status: str = Column(String(10), nullable=False)
 
     

--- a/lib/dao/repositories/user_repository.py
+++ b/lib/dao/repositories/user_repository.py
@@ -1,10 +1,11 @@
+from typing import List
 from sqlalchemy.orm import Session
 from lib.dao.models.user import User
 from lib.dao.database import get_database
 
 class UserRepository:
     @staticmethod
-    def find_all(database: Session = get_database()) -> list[User]:
+    def find_all(database: Session = get_database()) -> List[User]:
         '''Função para fazer uma query de todas as User da DB'''
         return database.query(User).all()
     
@@ -30,11 +31,24 @@ class UserRepository:
         return user
 
     @staticmethod
-    def update(user: User, database: Session = get_database()) -> User:
+    def update(firebase_uid: str ,user: User, database: Session = get_database()) -> User:
         '''Função para atualizar um objeto na DB'''
         try:
-            database.merge(user)
-            database.commit()
+            if user.cpf:
+                user.firebase_uid = firebase_uid
+                database.merge(user)
+                database.commit()
+        except:
+            database.rollback()
+        return user
+    
+    @staticmethod
+    def update_status(user: User, database: Session = get_database()) -> User:
+        '''Função para atualizar um objeto na DB'''
+        try:
+            if user.cpf:
+                database.merge(user)
+                database.commit()
         except:
             database.rollback()
         return user

--- a/lib/dao/repositories/user_repository.py
+++ b/lib/dao/repositories/user_repository.py
@@ -12,6 +12,11 @@ class UserRepository:
     def find_by_key(cpf, database: Session = get_database()) -> User:
         '''Função para fazer uma query com base no cpf'''
         return database.query(User).filter(User.cpf == cpf).first()
+
+    @staticmethod
+    def find_by_uid(firebase_uid, database: Session = get_database()) -> User:
+        '''Função para fazer uma query com base no cpf'''
+        return database.query(User).filter(User.firebase_uid == firebase_uid).first()
     
     @staticmethod
     def create(firebase_uid, user: User, database: Session = get_database()) -> User:


### PR DESCRIPTION
# Mudanças realizadas

Além da rota para pesquisar usuário pelo cpf agora temos para pesquisar pelo firebase_uid, respectivamente encontradas com:
/user/cpf/{cpf}
/user/uid/{firebase_uid}

Dessa forma ao utilizar ao fazer essas duas pesquisas, com prefixo ficaria
/users/user/cpf/{cpf}
/users/user/uid/{firebase_uid}

Além disso agora se retorna no corpo dessas requisições o firebase_uid, o que antes não acontecia.
Exemplo antes:
```json
{
	"name": "nome",
	"surname": "sobrenome",
	"email": "emailtest@gmail.com",
	"cpf": "12345678901",
	"is_admin": false,
	"telefone": "123456789",
	"status": "active",
}
```

Exemplo depois:
```json
{
	"name": "nome",
	"surname": "sobrenome",
	"email": "emailtest@gmail.com",
	"cpf": "12345678901",
	"is_admin": false,
	"telefone": "123456789",
	"status": "active",
	"firebase_uid": "XYZ"
}
```



